### PR TITLE
update repo URL (moved to rust-embedded-community)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   If your HAL does not yet implement this, then please use the previous release of the library.
 
 <!-- next-url -->
-[Unreleased]: https://github.com/rursprung/tb6612fng-rs/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/rursprung/tb6612fng-rs/compare/v0.1.1...v0.2.0
+[Unreleased]: https://github.com/rust-embedded-community/tb6612fng-rs/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/rust-embedded-community/tb6612fng-rs/compare/v0.1.1...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.63"
 
 description = "A `no_std` driver for the TB6612FNG motor driver."
-repository = "https://github.com/rursprung/tb6612fng-rs"
+repository = "https://github.com/rust-embedded-community/tb6612fng-rs"
 categories = ["embedded", "hardware-support", "no-std", "no-std::no-alloc"]
 keywords = ["tb6612fng", "driver", "motor", "controller", "embedded-hal-driver"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rust Driver for TB6612FNG Motor Driver
-[![CI](https://github.com/rursprung/tb6612fng-rs/actions/workflows/CI.yml/badge.svg)](https://github.com/rursprung/tb6612fng-rs/actions/workflows/CI.yml)
+[![CI](https://github.com/rust-embedded-community/tb6612fng-rs/actions/workflows/CI.yml/badge.svg)](https://github.com/rust-embedded-community/tb6612fng-rs/actions/workflows/CI.yml)
 [![Crates.io](https://img.shields.io/crates/v/tb6612fng)](https://crates.io/crates/tb6612fng)
 ![Licenses](https://img.shields.io/crates/l/tb6612fng)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
@@ -33,7 +33,7 @@ For the changelog please see the dedicated [CHANGELOG.md](CHANGELOG.md).
 This crate is already stable, however it's based on a release candidate version of [`embedded-hal`](https://github.com/rust-embedded/embedded-hal/),
 making the API unstable (the change from 1.0.0-rc.1 to 1.0.0 of e-h will be breaking from a dependency management point of view).
 
-See [the tracking issue](https://github.com/rursprung/tb6612fng-rs/issues/4) for the roadmap to v1.0.0.
+See [the tracking issue](https://github.com/rust-embedded-community/tb6612fng-rs/issues/4) for the roadmap to v1.0.0.
 
 ## Minimum Supported Rust Version (MSRV)
 This crate is guaranteed to compile on stable Rust 1.62 and up. It *might*

--- a/release.toml
+++ b/release.toml
@@ -3,5 +3,5 @@ pre-release-replacements = [
     {file="CHANGELOG.md", search="\\.\\.\\.HEAD", replace="...{{tag_name}}", exactly=1},
     {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
     {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## [Unreleased] - ReleaseDate\n", exactly=1},
-    {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/rursprung/tb6612fng-rs/compare/{{tag_name}}...HEAD", exactly=1},
+    {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/rust-embedded-community/tb6612fng-rs/compare/{{tag_name}}...HEAD", exactly=1},
 ]


### PR DESCRIPTION
the repository has found a new home in the [rust-embedded-community]! this will reduce the bus factor in the future.

as the repo has been moved all issues, PRs, etc. have been kept, ensuring that they can be found again in the future.

[rust-embedded-community]: https://github.com/rust-embedded-community