### PR TITLE
CI: install `cargo-audit`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt
+      - name: Install required cargo components
+        run: cargo install --locked cargo-audit
       - name: build
         run: cargo build ${{ matrix.features }}
       - name: check
@@ -44,7 +46,7 @@ jobs:
           targets: thumbv7em-none-eabihf
           components: rustfmt clippy
       - name: Install required cargo components
-        run: cargo install clippy-sarif sarif-fmt flip-link
+        run: cargo install --locked cargo-audit clippy-sarif sarif-fmt flip-link
       - name: build
         run: cargo build
         working-directory: examples/stm32f4-single-motor-example


### PR DESCRIPTION
GitHub recently changed the runners default image from Ubuntu 22.04 to 24.04 and in the process also changed the list of installed software. it seems, that `cargo-audit` is no longer installed by default. thus we now have to explicitly install it.